### PR TITLE
Included 'other' in research_types

### DIFF
--- a/R/rt_all_pmc.R
+++ b/R/rt_all_pmc.R
@@ -120,7 +120,8 @@
     "protocol",
     "letter",
     "brief-report",
-    "data-paper"
+    "data-paper",
+    "other"
   )
 
   review_types <- c(


### PR DESCRIPTION
When running _rt_all_pmc_ and _rt_data_code_pmc_ we noticed that they would very occasionally disagree as the whether an article should be classified as research or review. Specifically, _rt_all_pmc_ would occasionally not flag them as either. I think this is because the _other_ option was missing from the variable _research_types_ in _rt_all_pmc_. This change should make them classify articles identically.